### PR TITLE
Add Agent QA to Agent evaluation resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ Skills资源
 
 ### Agent评估
 
+- [Agent QA](https://github.com/vostride/agent-qa) - 源码可用的自改进 QA Agent，可通过自然语言执行 Web 与移动端测试，并提供持久测试记忆、CLI、Dashboard 和 MCP 服务.
 - [Anthropic万字长文：一篇AI Agent评估体系的详细解析！](https://mp.weixin.qq.com/s/C2Vpvm662STIohvnLQQgIQ)
 - [使用 Ragas 进行评估](https://milvus.io/docs/zh/integrate_with_ragas.md)
 


### PR DESCRIPTION
## Summary

- add Agent QA to the Agent Evaluation learning resources
- describe its natural-language web/mobile tests, persistent test memory, CLI, dashboard, and MCP server
- use the roadmap's existing one-line resource format

## Why it fits

[Agent QA](https://github.com/vostride/agent-qa) is a source-available, self-improving QA agent for software teams. It is a practical agentic testing resource alongside the section's evaluation methodology and Ragas material.

The current license is FSL-1.1-ALv2 and converts to Apache-2.0 after two years. I am affiliated with the project.

## Validation

- `git diff --check` passes.
- The project URL is unique in the README.
- The change is one focused list item under the existing Agent Evaluation heading.
- Standard `awesome-lint` reports the repository's existing baseline of eight errors and two warnings; the added line appears in none of its diagnostics.
